### PR TITLE
[FEAT] 서버로부터 불러온 학식 정보 로컬에 저장

### DIFF
--- a/ChulChulHanyang.xcodeproj/project.pbxproj
+++ b/ChulChulHanyang.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7610C52428B896DF00DB48C5 /* LocalKeyConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7610C52328B896DF00DB48C5 /* LocalKeyConstant.swift */; };
 		7622395C28ACCA38006F75F0 /* ParsingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7622395B28ACCA38006F75F0 /* ParsingManager.swift */; };
 		7622395D28AD3CAF006F75F0 /* ParsingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7622395B28ACCA38006F75F0 /* ParsingManager.swift */; };
 		762BB6F628B785A90072C317 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762BB6F528B785A90072C317 /* APIError.swift */; };
@@ -72,6 +73,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7610C52328B896DF00DB48C5 /* LocalKeyConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalKeyConstant.swift; sourceTree = "<group>"; };
 		7622395B28ACCA38006F75F0 /* ParsingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsingManager.swift; sourceTree = "<group>"; };
 		762BB6F528B785A90072C317 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		762BB6FD28B7A1F90072C317 /* LoadingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingService.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				76C2B1FD28A1FE22008AF214 /* RestaurantType.swift */,
 				762BB6F528B785A90072C317 /* APIError.swift */,
 				762BB6FD28B7A1F90072C317 /* LoadingService.swift */,
+				7610C52328B896DF00DB48C5 /* LocalKeyConstant.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -396,6 +399,7 @@
 				767D1CB7289FE428006DF76F /* SceneDelegate.swift in Sources */,
 				76C2B1FE28A1FE22008AF214 /* RestaurantType.swift in Sources */,
 				76EC20FE28A1542D00FDD319 /* CrawlManager.swift in Sources */,
+				7610C52428B896DF00DB48C5 /* LocalKeyConstant.swift in Sources */,
 				762BB6F628B785A90072C317 /* APIError.swift in Sources */,
 				767D1CD3289FF537006DF76F /* Date+Extension.swift in Sources */,
 				767D1CDE28A0B7C6006DF76F /* UIColor+Extension.swift in Sources */,

--- a/ChulChulHanyang/Globals/Extension/Date+Extension.swift
+++ b/ChulChulHanyang/Globals/Extension/Date+Extension.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 extension Date {
+        
+    var keyText: String {
+        return DateFormatterLiteral.yearDateFormatter.string(from: self)
+    }
     
     var dateText: String {
         return DateFormatterLiteral.dateDateFormatter.string(from: self)
@@ -31,5 +35,16 @@ extension Date {
     
     var hour: Int {
         return Calendar.current.component(.hour, from: self)
+    }
+    
+//  한양대 서버 데이터가 현재일로부터 1주일까진 최신 업데이트가 되어 있기 때문에 해당 기간을 넘어선다면 로컬에서 다시 reload받아야 한다.
+    func lessThanSevenDays() -> Bool {
+        let today = Date()
+        let day = Calendar.current.dateComponents([.day], from: today, to: self)
+        if let difference = day.day, difference > 7 {
+            return false
+        }
+        return true
+       
     }
 }

--- a/ChulChulHanyang/Globals/Extension/Date+Extension.swift
+++ b/ChulChulHanyang/Globals/Extension/Date+Extension.swift
@@ -21,6 +21,15 @@ extension Date {
         return DateFormatterLiteral.dayDateFormatter.string(from: self)
     }
     
+    var sevenDaysBeforeText: String {
+        
+        guard let sevenDaysBefore = Calendar.current.date(byAdding: .day, value: -7, to: self) else {
+            return ""
+        }
+        return sevenDaysBefore.keyText
+        
+    }
+    
     var year: Int {
         return Calendar.current.component(.year, from: self)
     }

--- a/ChulChulHanyang/Globals/Helper/DateFormatter.swift
+++ b/ChulChulHanyang/Globals/Helper/DateFormatter.swift
@@ -9,6 +9,13 @@ import Foundation
 
 final class DateFormatterLiteral {
     
+    static let yearDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "YYYYMMDD"
+        return formatter
+    }()
+    
     static let dateDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")

--- a/ChulChulHanyang/Globals/Helper/DateFormatter.swift
+++ b/ChulChulHanyang/Globals/Helper/DateFormatter.swift
@@ -12,7 +12,7 @@ final class DateFormatterLiteral {
     static let yearDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "YYYYMMDD"
+        formatter.dateFormat = "YYYYMMdd"
         return formatter
     }()
     

--- a/ChulChulHanyang/Globals/Helper/LocalKeyConstant.swift
+++ b/ChulChulHanyang/Globals/Helper/LocalKeyConstant.swift
@@ -1,0 +1,19 @@
+//
+//  KeyFormat.swift
+//  ChulChulHanyang
+//
+//  Created by yudonlee on 2022/08/26.
+//
+
+import Foundation
+
+struct LocalKeyConstant {
+    static let breakfast = "breakfast"
+    static let lunch = "lunch"
+    static let dinner = "dinner"
+    
+//    한양 플라자 분식
+    static let snack = "snack"
+//    한양 플라자 중식/석식
+    static let meal = "meal"
+}


### PR DESCRIPTION
## 🍚 구현/변경 사항 및 이유
### 구현방식
1. 크롤링은 RestAPI와 달리 http파일 전체를 받아와서 파싱을 해야하는 구조이기 때문에 더 많은 시간이 소요된다.
2. 그리하여 한번 크롤링으로 받아온 학식은 로컬에 저장하고 계속 재사용을 하는 구조로 구현해야한다.
3. 하지만 학식 메뉴는 일주일전까지 "확정"되지 않는 경우가 있기 때문에, 로컬에서의 저장은 현재일을 기준으로 앞뒤로 7일까지만 저장하도록 한다. 
4. 학식 메뉴들이 모두 String형태이고, 모든 데이터가 로컬에 저장될 필요가 없기 때문에 CoreData를 사용하지 않았다.(UserDefault의 성격인 가벼운 캐시데이터만을 저장하는게 알맞았다.)
5. 하지만 학식메뉴 업데이트가 전날까지 되지 않는 날도 존재했기에, 결국 UserDefault에 해당 식당 메뉴 정보가 "오늘"인 경우만 저장하도록 logic을 변경하였다. 
6. 만약 다음날이 된다면 해당 UserDefault의 key의 value가 업데이트 된다.(이전건 삭제된다.) 
### 해결한 문제점
1. 기존엔 "오늘의 메뉴"를 보는데 또다른 식당을 확인하고 다시 돌아왔을 때 또다시 불러와야 하는 문제를 해결했다.(식당 메뉴가 오늘인 경우에만 local에 저장된다)
2. 그리하여 한양대학교 학식 서버의 부담을 최소화했다.(오늘의 메뉴를 확인하는데 6개의 식당을 하루에 6번 request하게 되었다.) 

## 🍚 참고 사항
![Simulator Screen Recording - iPhone 13 Pro Max - 2022-10-31 at 15 24 32](https://user-images.githubusercontent.com/39371835/198944685-14667a38-ee7b-4f93-bae6-f08cea20d8a1.gif)

오늘의 메뉴는 한번 확인했을 떄 저장되며, 다음날이 되면 다른 메뉴가 로딩된다. 
