### PR TITLE
[FEAT]: WidgetKit Networking URLSession으로 전환 

### DIFF
--- a/ChulChulHanyang.xcodeproj/project.pbxproj
+++ b/ChulChulHanyang.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		7693536728AB2ADE007F2F81 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7693537A28ABC660007F2F81 /* ChulChulHanyangWidgetEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChulChulHanyangWidgetEntryView.swift; sourceTree = "<group>"; };
 		76C2B1FD28A1FE22008AF214 /* RestaurantType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantType.swift; sourceTree = "<group>"; };
+		76E97ED628BB54C10018D50C /* ChulChulHanyang.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChulChulHanyang.entitlements; sourceTree = "<group>"; };
+		76E97ED728BB5DA10018D50C /* ChulChulHanyangWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChulChulHanyangWidgetExtension.entitlements; sourceTree = "<group>"; };
 		76EC20F028A101D900FDD319 /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
 		76EC20F728A14E6800FDD319 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		76EC20FD28A1542D00FDD319 /* CrawlManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlManager.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 		767D1CA8289FE428006DF76F = {
 			isa = PBXGroup;
 			children = (
+				76E97ED728BB5DA10018D50C /* ChulChulHanyangWidgetExtension.entitlements */,
 				767D1CB3289FE428006DF76F /* ChulChulHanyang */,
 				7693536128AB2ADD007F2F81 /* ChulChulHanyangWidget */,
 				7693535C28AB2ADD007F2F81 /* Frameworks */,
@@ -161,6 +164,7 @@
 		767D1CB3289FE428006DF76F /* ChulChulHanyang */ = {
 			isa = PBXGroup;
 			children = (
+				76E97ED628BB54C10018D50C /* ChulChulHanyang.entitlements */,
 				767D1CCE289FEB54006DF76F /* Globals */,
 				767D1CDF28A0EAC9006DF76F /* ViewModels */,
 				767D1CCB289FE8F7006DF76F /* View */,
@@ -573,6 +577,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ChulChulHanyang/ChulChulHanyang.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
@@ -604,6 +609,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = ChulChulHanyang/ChulChulHanyang.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
@@ -634,6 +640,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = ChulChulHanyangWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
@@ -662,6 +669,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = ChulChulHanyangWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;

--- a/ChulChulHanyang/AppDelegate.swift
+++ b/ChulChulHanyang/AppDelegate.swift
@@ -24,7 +24,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.

--- a/ChulChulHanyang/ChulChulHanyang.entitlements
+++ b/ChulChulHanyang/ChulChulHanyang.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array/>
+</dict>
+</plist>

--- a/ChulChulHanyang/ChulChulHanyang.entitlements
+++ b/ChulChulHanyang/ChulChulHanyang.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.application-groups</key>
-	<array/>
-</dict>
+<dict/>
 </plist>

--- a/ChulChulHanyang/Globals/Helper/RestaurantType.swift
+++ b/ChulChulHanyang/Globals/Helper/RestaurantType.swift
@@ -63,7 +63,7 @@ enum RestaurantType: Int {
         case .ResidenceTwo:
             return ["조식": "07:30 ~ 09:00", "중식": "12:00 ~ 13:30", "석식": "17:30 ~ 18:30"]
         case .HangwonPark:
-            return ["점심": "11:30 ~ 14:00"]
+            return ["중식": "11:30 ~ 14:00"]
         }
     }
 }

--- a/ChulChulHanyang/Globals/Manager/CrawlManager.swift
+++ b/ChulChulHanyang/Globals/Manager/CrawlManager.swift
@@ -91,10 +91,16 @@ final class CrawlManager {
     
         var removedData = str
         
+//        영어메뉴 삭제 
+        if type == .HanyangPlaza || type == .ResidenceTwo {
+            removedData = removedData.replacingOccurrences(of: "[a-zA-Z]", with: "", options: .regularExpression)
+        }
+        
         if type != .HanyangPlaza {
+            
             removedData.removeAll(where: { [","].contains($0) })
             let convertedStrArray = removedData.components(separatedBy: " ").map { String($0) }.filter { element in
-                !element.contains("00원")
+                !element.contains("00원") && !element.isEmpty
             }
             return convertedStrArray
         } else {
@@ -102,8 +108,6 @@ final class CrawlManager {
                 return ramenInformation
             }
             
-//                학생식당 영어 번역 메뉴 삭제
-            removedData = removedData.replacingOccurrences(of: "[a-zA-Z]", with: "", options: .regularExpression)
             removedData.removeAll(where: { [","].contains($0) })
             let convertedStrArray = removedData.components(separatedBy: " ").map { String($0) }.filter { element in
                 return !element.isEmpty && !(element.contains(":")) &&

--- a/ChulChulHanyangWidget/ChulChulHanyangWidget.swift
+++ b/ChulChulHanyangWidget/ChulChulHanyangWidget.swift
@@ -10,24 +10,43 @@ import SwiftUI
 import Intents
 
 struct Provider: IntentTimelineProvider {
+    let type: RestaurantType
+    
     func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), configuration: ConfigurationIntent())
+        
+        SimpleEntry(date: Date(), configuration: ConfigurationIntent(), data: [])
     }
 
     func getSnapshot(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (SimpleEntry) -> ()) {
-        let entry = SimpleEntry(date: Date(), configuration: configuration)
-        completion(entry)
+        ParsingManager.parsingAsync(type: type) { result in
+            switch result {
+            case .success(let data):
+                let entry = SimpleEntry(date: Date(), configuration: configuration, data: data)
+                completion(entry)
+            case .failure(let error):
+                let entry = SimpleEntry(date: Date(), configuration: configuration, data: [])
+                completion(entry)
+            }
+        }
+        
     }
 
     func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<SimpleEntry>) -> ()) {
         
-        let entry = SimpleEntry(date: Date(), configuration: configuration)
-        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: Date())
-        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate!))
-        completion(timeline)
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: Date())!
         
-        
-        
+        ParsingManager.parsingAsync(type: type) { result in
+            switch result {
+            case .success(let data):
+                let entry = SimpleEntry(date: Date(), configuration: configuration, data: data)
+                let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+                completion(timeline)
+            case .failure(let error):
+                let entry = SimpleEntry(date: Date(), configuration: configuration, data: [])
+                let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+                completion(timeline)
+            }
+        }
     }
 }
 
@@ -35,6 +54,7 @@ struct Provider: IntentTimelineProvider {
 struct SimpleEntry: TimelineEntry {
     let date: Date
     let configuration: ConfigurationIntent
+    let data: [String]
 }
 
 
@@ -66,7 +86,7 @@ struct HumanEcologyWidget: Widget {
     let kind: String = "HumanEcologyWidget"
 
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(type: .HumanEcology)) { entry in
             ChulChulHanyangWidgetEntryView(entry: entry, type: .HumanEcology)
         }
         .configurationDisplayName("생과대 교직원 식당")
@@ -79,7 +99,7 @@ struct MaterialScienceWidget: Widget {
     let kind: String = "MaterialScienceWidget"
 
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(type: .MaterialScience)) { entry in
             ChulChulHanyangWidgetEntryView(entry: entry, type: .MaterialScience)
         }
         .configurationDisplayName("신소재 교직원 식당")
@@ -92,7 +112,7 @@ struct ResidenceOneWidget: Widget {
     let kind: String = "ResidenceOneWidget"
 
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(type: .ResidenceOne)) { entry in
             ChulChulHanyangWidgetEntryView(entry: entry, type: .ResidenceOne)
         }
         .configurationDisplayName("제 1생활관 식당 위젯")
@@ -105,7 +125,7 @@ struct ResidenceTwoWidget: Widget {
     let kind: String = "ResidenceTwoWidget"
 
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(type: .ResidenceTwo)) { entry in
             ChulChulHanyangWidgetEntryView(entry: entry, type: .ResidenceTwo)
         }
         .configurationDisplayName("제 2생활관 식당 위젯")
@@ -119,7 +139,7 @@ struct HanyangPlazaWidget: Widget {
     let kind: String = "HanyangPlazaWidget"
 
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(type: .HanyangPlaza)) { entry in
             ChulChulHanyangWidgetEntryView(entry: entry, type: .HanyangPlaza)
         }
         .configurationDisplayName("학생 식당")
@@ -132,7 +152,7 @@ struct HangwonParkWidget: Widget {
     let kind: String = "HangwonParkWidget"
 
     var body: some WidgetConfiguration {
-        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider(type: .HangwonPark)) { entry in
             ChulChulHanyangWidgetEntryView(entry: entry, type: .HangwonPark)
         }
         .configurationDisplayName("행원파크 식당")

--- a/ChulChulHanyangWidget/ChulChulHanyangWidgetEntryView.swift
+++ b/ChulChulHanyangWidget/ChulChulHanyangWidgetEntryView.swift
@@ -24,7 +24,7 @@ struct ChulChulHanyangWidgetEntryView : View {
     func widgetBody() -> some View {
         switch family {
         case .systemSmall:
-            WidgetSmallView(type: type)
+            WidgetSmallView(type: type, menu: entry.data)
         case .systemMedium:
             Text("Test")
         default:
@@ -38,21 +38,21 @@ struct ChulChulHanyangWidgetEntryView : View {
 
 
 struct WidgetSmallView: View {
-    
     var type: RestaurantType
-    var menu: [String]  {
-        return ParsingManager.parsing(type: type)
-    }
+    var menu: [String]
+    var foodTime: [String] = ["조식", "중식", "석식", "분식", "중식/석식"]
     
     var body: some View {
-        VStack{
-            Text("\(type.name)").font(.system(size: 12, weight: .bold))
+        VStack(alignment: .center) {
+            
+            Text("\(type.name)").font(.system(size: 14, weight: .bold))
             if !menu.isEmpty {
                 ForEach(menu, id: \.self) { food in
-                    Text(food).font(.system(size: 13, weight: .medium))
+                    Text(food).font(.system(size: !foodTime.contains(food) ?  13 :14, weight: !foodTime.contains(food) ? .medium : .bold))
                 }
             } else {
-                Text("등록된 정보를 찾지 못했어요😢").font(.system(size: 13, weight: .medium))
+                Text("등록된 정보를").font(.system(size: 13, weight: .medium))
+                Text("찾지 못했어요😢").font(.system(size: 13, weight: .medium))
             }
         }
     }

--- a/ChulChulHanyangWidget/Manager/ParsingManager.swift
+++ b/ChulChulHanyangWidget/Manager/ParsingManager.swift
@@ -31,6 +31,270 @@ struct ParsingManager {
         return "중식"
     }
     
+    static private func isUserDefaultDataToday(type: RestaurantType) -> Bool {
+        let dateText: String = {
+            let date = Date()
+            return date.keyText
+        }()
+        
+        if UserDefaults.standard.string(forKey: "DateOf\(type.name)") == "\(dateText)" {
+            return true
+        }
+        return false
+    }
+    
+    static private func shouldUserDefaultUpdate(type: RestaurantType) -> Bool {
+        
+        let dateText: String = {
+            let date = Date()
+            return date.keyText
+        }()
+        
+        
+        guard let data = UserDefaults.standard.string(forKey: "DateOf\(type.name)") else {
+            return true
+        }
+        
+        if data != "\(dateText)" {
+            return true
+        }
+        
+        return false
+        
+    }
+    
+    
+    static func parsingAsync(type: RestaurantType, completion: @escaping (Result<[String], Error>) -> Void) {
+        
+        CrawlManager.shared.crawlRestaurantMenuAsyncAndURL(date: Date(), restaurantType: type) { result in
+            switch result {
+            case .success(let data):
+                var parsedData = [String]()
+                
+                let getTimeStamp = getMealTime(type: type)
+                
+                switch type {
+                case .HanyangPlaza:
+                    parsedData = data.filter { str in
+                        str.contains("중식/석식")
+                    }.flatMap({ $0 })
+                    
+                case .HumanEcology:
+                    parsedData = data.filter { str in
+                        str.contains(getTimeStamp)
+                    }.flatMap({ $0 })
+                    
+                    if let damAIndex = parsedData.firstIndex(of: "[Dam-A]"),
+                       let pangeosIndex = parsedData.firstIndex(of: "[Pangeos]") {
+                        
+                        let range = pangeosIndex..<parsedData.endIndex
+                        parsedData.removeSubrange(range)
+                    }
+                    
+                    
+                case .MaterialScience:
+                    parsedData = data.filter { str in
+                        str.contains(getTimeStamp)
+                    }.flatMap({ $0 })
+                    
+                    if let jeongsikIndex = parsedData.firstIndex(of: "[정식]"),
+                       let ilpoomIndex = parsedData.firstIndex(of: "[일품]") {
+                        
+                        let range = ilpoomIndex..<parsedData.endIndex
+                        parsedData.removeSubrange(range)
+                    }
+                    
+                case .ResidenceOne, .ResidenceTwo:
+                    parsedData = data.filter { str in
+                        str.contains(getTimeStamp)
+                    }.flatMap({ $0 })
+                    
+                    
+                case .HangwonPark:
+                    var result = data.filter { str in
+                        str.contains(getTimeStamp)
+                    }.flatMap({ $0 })
+                    
+                    if let cornerAIndex = result.firstIndex(of: "[코너 A]"),
+                       let cornerBIndex = result.firstIndex(of: "[코너 B]") {
+                        
+                        let range = cornerBIndex..<result.endIndex
+                        result.removeSubrange(range)
+                    }
+                    
+                }
+                
+                parsedData = parsedData.filter { str in
+                    return str != "-"
+                }
+                completion(.success(parsedData))
+                
+            case .failure(let error):
+                completion(.failure(error))
+                
+            }
+        }
+    }
+    
+    
+    static func parsingAsyncAndLocal(type: RestaurantType, completion: @escaping (Result<[String], Error>) -> Void) {
+        
+        let dateText: String = {
+            let date = Date()
+            return date.keyText
+        }()
+//        if false {
+        print(UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)"))
+        if isUserDefaultDataToday(type: type), let data = UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
+//            var data: [[String]] = []
+            var parsedData = [String]()
+            
+            let getTimeStamp = getMealTime(type: type)
+            
+            switch type {
+            case .HanyangPlaza:
+                parsedData = data.filter { str in
+                    str.contains("중식/석식")
+                }.flatMap({ $0 })
+                
+            case .HumanEcology:
+                parsedData = data.filter { str in
+                    str.contains(getTimeStamp)
+                }.flatMap({ $0 })
+                
+                if let damAIndex = parsedData.firstIndex(of: "[Dam-A]"),
+                   let pangeosIndex = parsedData.firstIndex(of: "[Pangeos]") {
+                    
+                    let range = pangeosIndex..<parsedData.endIndex
+                    parsedData.removeSubrange(range)
+                }
+                
+                
+            case .MaterialScience:
+                parsedData = data.filter { str in
+                    str.contains(getTimeStamp)
+                }.flatMap({ $0 })
+                
+                if let jeongsikIndex = parsedData.firstIndex(of: "[정식]"),
+                   let ilpoomIndex = parsedData.firstIndex(of: "[일품]") {
+                    
+                    let range = ilpoomIndex..<parsedData.endIndex
+                    parsedData.removeSubrange(range)
+                }
+                
+            case .ResidenceOne, .ResidenceTwo:
+                parsedData = data.filter { str in
+                    str.contains(getTimeStamp)
+                }.flatMap({ $0 })
+                
+            case .HangwonPark:
+                var result = data.filter { str in
+                    str.contains(getTimeStamp)
+                }.flatMap({ $0 })
+                
+                if let cornerAIndex = result.firstIndex(of: "[코너 A]"),
+                   let cornerBIndex = result.firstIndex(of: "[코너 B]") {
+                    
+                    let range = cornerBIndex..<result.endIndex
+                    result.removeSubrange(range)
+                }
+                
+            }
+            
+            parsedData = parsedData.filter { str in
+                return str != "-"
+            }
+            completion(.success(parsedData))
+        }
+        
+        else {
+            CrawlManager.shared.crawlRestaurantMenuAsyncAndURL(date: Date(), restaurantType: type) { result in
+                switch result {
+                case .success(let data):
+                    let parsed = data.map({ strArray in
+                        strArray.filter { str in
+                            !["-"].contains(str)
+                        }
+                    })
+                    
+                    if shouldUserDefaultUpdate(type: type) {
+                        UserDefaults.standard.set("\(dateText)", forKey: "DateOf\(type.name)")
+                        print(UserDefaults.standard.string(forKey: "DateOf\(type.name)"))
+                        UserDefaults.standard.set(parsed, forKey: "TodayMenuOf\(type.name)")
+                        print(UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)"))
+                    }
+                    
+                    var parsedData = [String]()
+                    
+                    let getTimeStamp = getMealTime(type: type)
+                    
+                    switch type {
+                    case .HanyangPlaza:
+                        parsedData = data.filter { str in
+                            str.contains("중식/석식")
+                        }.flatMap({ $0 })
+                        
+                    case .HumanEcology:
+                        parsedData = data.filter { str in
+                            str.contains(getTimeStamp)
+                        }.flatMap({ $0 })
+                        
+                        if let damAIndex = parsedData.firstIndex(of: "[Dam-A]"),
+                           let pangeosIndex = parsedData.firstIndex(of: "[Pangeos]") {
+                            
+                            let range = pangeosIndex..<parsedData.endIndex
+                            parsedData.removeSubrange(range)
+                        }
+                        
+                        
+                    case .MaterialScience:
+                        parsedData = data.filter { str in
+                            str.contains(getTimeStamp)
+                        }.flatMap({ $0 })
+                        
+                        if let jeongsikIndex = parsedData.firstIndex(of: "[정식]"),
+                           let ilpoomIndex = parsedData.firstIndex(of: "[일품]") {
+                            
+                            let range = ilpoomIndex..<parsedData.endIndex
+                            parsedData.removeSubrange(range)
+                        }
+                        
+                    case .ResidenceOne, .ResidenceTwo:
+                        parsedData = data.filter { str in
+                            str.contains(getTimeStamp)
+                        }.flatMap({ $0 })
+                    case .HangwonPark:
+                        var result = data.filter { str in
+                            str.contains(getTimeStamp)
+                        }.flatMap({ $0 })
+                        
+                        if let cornerAIndex = result.firstIndex(of: "[코너 A]"),
+                           let cornerBIndex = result.firstIndex(of: "[코너 B]") {
+                            
+                            let range = cornerBIndex..<result.endIndex
+                            result.removeSubrange(range)
+                        }
+                        
+                    }
+                    
+                    parsedData = parsedData.filter { str in
+                        return str != "-"
+                    }
+                    completion(.success(parsedData))
+                    
+                case .failure(let error):
+                    completion(.failure(error))
+                    
+                }
+            }
+            
+        }
+        
+        
+        
+    }
+    
+    
     static func parsing(type: RestaurantType) -> [String] {
         guard let data = CrawlManager.shared.crawlRestaurantMenu(date: Date(), restaurantType: type) else {
             return [String]()
@@ -45,7 +309,7 @@ struct ParsingManager {
             result = data.filter { str in
                 str.contains("중식/석식")
             }.flatMap({ $0 })
-        
+            
         case .HumanEcology:
             result = data.filter { str in
                 str.contains(getTimeStamp)
@@ -94,4 +358,5 @@ struct ParsingManager {
         }
         return result
     }
+    
 }

--- a/ChulChulHanyangWidget/Manager/ParsingManager.swift
+++ b/ChulChulHanyangWidget/Manager/ParsingManager.swift
@@ -143,10 +143,7 @@ struct ParsingManager {
             let date = Date()
             return date.keyText
         }()
-//        if false {
-        print(UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)"))
         if isUserDefaultDataToday(type: type), let data = UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
-//            var data: [[String]] = []
             var parsedData = [String]()
             
             let getTimeStamp = getMealTime(type: type)

--- a/ChulChulHanyangWidgetExtension.entitlements
+++ b/ChulChulHanyangWidgetExtension.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array/>
+</dict>
+</plist>

--- a/ChulChulHanyangWidgetExtension.entitlements
+++ b/ChulChulHanyangWidgetExtension.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.application-groups</key>
-	<array/>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION
## 관련이슈 
- close #30 
## 🍚 구현/변경 사항 및 이유
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
### 문제점 
- 기존 http 통신에선 try String을 통해서 시리얼하게 동작, Bottleneck으로 작용
- 이를 URLSession을 통한 통신으로 바꿔 주었고 이를 이제 Widget에도 적용

### 해결책
- Widget의 화면 갱신을 담당하는 Provider가 존재하고 이를 조작하여 서버로부터 데이터를 받아올 수 있도록 한다.
- Provider에서 식당 타입을 받아, 해당 식당에 맞는 데이터를 제공
- getTimeline으로 rendering timeline을 주면서 별도로 서버로부터 불러온 데이터를 위젯에 주입한다. 
- 이때 next rendering을 전달하지 않고, refresh policy를 1시간 뒤로 설정하여, 다시 timeline reload가 발생한다.

## 🍚 참고 사항
### 1. Apple WidgetKit 설명
<img src = https://docs-assets.developer.apple.com/published/98d04d83e50d24aa56ec117d99d76a94/WidgetKit-Timeline-At-End@2x.png width = "400">

- timeline에 SimpleEntry들이 1시간 단위로 값을 주입시킨다면, 해당 데이터들은 1시간마다 widget이 렌더링되며 그때 주입받은 SimpleEntry의 내부 데이터를 사용하게 된다. 
- 주입받은 1시간 단위 데이터들을 모두 rendering하면, Widget은 timeline을 reload하게 된다. 
- 하지만 여기 코드의 경우 refresh policy를 적용하여 1시간마다 widget time line이 reload하게 된다(Not rendering)

## 🍚Reference
https://developer.apple.com/documentation/widgetkit/keeping-a-widget-up-to-date
https://zeddios.tistory.com/1089


