### PR TITLE
[FEAT]: App과 Extension간 데이터 공유

### DIFF
--- a/ChulChulHanyang.xcodeproj/project.pbxproj
+++ b/ChulChulHanyang.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		7693537728AB2DB5007F2F81 /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767D1CD5289FF723006DF76F /* DateFormatter.swift */; };
 		7693537C28ABC67F007F2F81 /* ChulChulHanyangWidgetEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7693537A28ABC660007F2F81 /* ChulChulHanyangWidgetEntryView.swift */; };
 		76C2B1FE28A1FE22008AF214 /* RestaurantType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76C2B1FD28A1FE22008AF214 /* RestaurantType.swift */; };
+		76E97EFE28BE01B20018D50C /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E97EFD28BE01B20018D50C /* UserDefaults+Extension.swift */; };
+		76E97EFF28BE04430018D50C /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E97EFD28BE01B20018D50C /* UserDefaults+Extension.swift */; };
 		76EC20F128A101D900FDD319 /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC20F028A101D900FDD319 /* UIScreen+Extension.swift */; };
 		76EC20FB28A1519D00FDD319 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 76EC20FA28A1519D00FDD319 /* SwiftSoup */; };
 		76EC20FE28A1542D00FDD319 /* CrawlManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EC20FD28A1542D00FDD319 /* CrawlManager.swift */; };
@@ -106,6 +108,7 @@
 		76C2B1FD28A1FE22008AF214 /* RestaurantType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantType.swift; sourceTree = "<group>"; };
 		76E97ED628BB54C10018D50C /* ChulChulHanyang.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChulChulHanyang.entitlements; sourceTree = "<group>"; };
 		76E97ED728BB5DA10018D50C /* ChulChulHanyangWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ChulChulHanyangWidgetExtension.entitlements; sourceTree = "<group>"; };
+		76E97EFD28BE01B20018D50C /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		76EC20F028A101D900FDD319 /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
 		76EC20F728A14E6800FDD319 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		76EC20FD28A1542D00FDD319 /* CrawlManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrawlManager.swift; sourceTree = "<group>"; };
@@ -215,6 +218,7 @@
 				767D1CDD28A0B7C6006DF76F /* UIColor+Extension.swift */,
 				767D1CE828A0F23D006DF76F /* UITableView+Extension.swift */,
 				76EC20F028A101D900FDD319 /* UIScreen+Extension.swift */,
+				76E97EFD28BE01B20018D50C /* UserDefaults+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -404,6 +408,7 @@
 				76C2B1FE28A1FE22008AF214 /* RestaurantType.swift in Sources */,
 				76EC20FE28A1542D00FDD319 /* CrawlManager.swift in Sources */,
 				7610C52428B896DF00DB48C5 /* LocalKeyConstant.swift in Sources */,
+				76E97EFE28BE01B20018D50C /* UserDefaults+Extension.swift in Sources */,
 				762BB6F628B785A90072C317 /* APIError.swift in Sources */,
 				767D1CD3289FF537006DF76F /* Date+Extension.swift in Sources */,
 				767D1CDE28A0B7C6006DF76F /* UIColor+Extension.swift in Sources */,
@@ -426,6 +431,7 @@
 				7693537428AB2D6A007F2F81 /* CrawlManager.swift in Sources */,
 				7693537528AB2D97007F2F81 /* RestaurantType.swift in Sources */,
 				7693536828AB2ADE007F2F81 /* ChulChulHanyangWidget.intentdefinition in Sources */,
+				76E97EFF28BE04430018D50C /* UserDefaults+Extension.swift in Sources */,
 				762BB6F728B785DB0072C317 /* APIError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -579,7 +585,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyang/ChulChulHanyang.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyang/Info.plist;
@@ -594,7 +600,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -611,7 +617,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyang/ChulChulHanyang.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyang/Info.plist;
@@ -626,7 +632,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -642,7 +648,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyangWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyangWidget/Info.plist;
@@ -654,7 +660,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang.ChulChulHanyangWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -671,7 +677,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyangWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyangWidget/Info.plist;
@@ -683,7 +689,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang.ChulChulHanyangWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ChulChulHanyang.xcodeproj/project.pbxproj
+++ b/ChulChulHanyang.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyang/ChulChulHanyang.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyang/Info.plist;
@@ -600,7 +600,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -617,7 +617,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyang/ChulChulHanyang.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyang/Info.plist;
@@ -632,7 +632,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -648,7 +648,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyangWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyangWidget/Info.plist;
@@ -660,7 +660,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang.ChulChulHanyangWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -677,7 +677,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = ChulChulHanyangWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2RG6A633V9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ChulChulHanyangWidget/Info.plist;
@@ -689,7 +689,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = yudonlee.ChulChulHanyang.ChulChulHanyangWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ChulChulHanyang/ChulChulHanyang.entitlements
+++ b/ChulChulHanyang/ChulChulHanyang.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ChulChulHanyang</string>
+	</array>
+</dict>
 </plist>

--- a/ChulChulHanyang/Globals/Extension/UserDefaults+Extension.swift
+++ b/ChulChulHanyang/Globals/Extension/UserDefaults+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  UserDefaults+Extension.swift
+//  ChulChulHanyang
+//
+//  Created by yudonlee on 2022/08/30.
+//
+
+import Foundation
+
+extension UserDefaults {
+    static var shared: UserDefaults {
+        let groupID = "group.ChulChulHanyang"
+        return UserDefaults(suiteName: groupID)!
+    }
+}

--- a/ChulChulHanyang/View/RestaurantListView.swift
+++ b/ChulChulHanyang/View/RestaurantListView.swift
@@ -89,7 +89,7 @@ extension RestaurantListView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RestaurantCollectionViewCell.identifier, for: indexPath) as? RestaurantCollectionViewCell else {
-            assert(false, "Wrong Cell")
+            return UICollectionViewCell()
         }
         
         cell.configure(with: restaurantName[indexPath.item])

--- a/ChulChulHanyang/controllers/MainViewController.swift
+++ b/ChulChulHanyang/controllers/MainViewController.swift
@@ -55,7 +55,7 @@ final class MainViewController: UIViewController {
     }
     
     private func isUserDefaultDataToday() -> Bool {
-        if Calendar.current.isDateInToday(date), UserDefaults.standard.string(forKey: "DateOf\(type.name)") == "\(date.keyText)" {
+        if Calendar.current.isDateInToday(date), UserDefaults.shared.string(forKey: "DateOf\(type.name)") == "\(date.keyText)" {
             return true
         }
         return false
@@ -69,7 +69,7 @@ final class MainViewController: UIViewController {
         }()
         
         if Calendar.current.isDateInToday(date) {
-            guard let data = UserDefaults.standard.string(forKey: "DateOf\(type.name)") else {
+            guard let data = UserDefaults.shared.string(forKey: "DateOf\(type.name)") else {
                 return true
             }
             
@@ -83,7 +83,7 @@ final class MainViewController: UIViewController {
     
     func requestData() {
         
-        if isUserDefaultDataToday(), let data = UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
+        if isUserDefaultDataToday(), let data = UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
             DispatchQueue.main.async { [weak self] in
                 self?.data = data
                 self?.dietCollectionView.reloadData()
@@ -101,8 +101,8 @@ final class MainViewController: UIViewController {
                     })
                     
                     if shouldUserDefaultUpdate() {
-                        UserDefaults.standard.set("\(date.keyText)", forKey: "DateOf\(type.name)")
-                        UserDefaults.standard.set(parsed, forKey: "TodayMenuOf\(self.type.name)")
+                        UserDefaults.shared.set("\(date.keyText)", forKey: "DateOf\(type.name)")
+                        UserDefaults.shared.set(parsed, forKey: "TodayMenuOf\(self.type.name)")
                     }
                     LoadingService.hideLoading()
                     DispatchQueue.main.async { [weak self] in

--- a/ChulChulHanyangWidget/Manager/ParsingManager.swift
+++ b/ChulChulHanyangWidget/Manager/ParsingManager.swift
@@ -37,7 +37,7 @@ struct ParsingManager {
             return date.keyText
         }()
         
-        if UserDefaults.standard.string(forKey: "DateOf\(type.name)") == "\(dateText)" {
+        if UserDefaults.shared.string(forKey: "DateOf\(type.name)") == "\(dateText)" {
             return true
         }
         return false
@@ -51,7 +51,7 @@ struct ParsingManager {
         }()
         
         
-        guard let data = UserDefaults.standard.string(forKey: "DateOf\(type.name)") else {
+        guard let data = UserDefaults.shared.string(forKey: "DateOf\(type.name)") else {
             return true
         }
         
@@ -63,89 +63,15 @@ struct ParsingManager {
         
     }
     
-    
     static func parsingAsync(type: RestaurantType, completion: @escaping (Result<[String], Error>) -> Void) {
-        
-        CrawlManager.shared.crawlRestaurantMenuAsyncAndURL(date: Date(), restaurantType: type) { result in
-            switch result {
-            case .success(let data):
-                var parsedData = [String]()
-                
-                let getTimeStamp = getMealTime(type: type)
-                
-                switch type {
-                case .HanyangPlaza:
-                    parsedData = data.filter { str in
-                        str.contains("중식/석식")
-                    }.flatMap({ $0 })
-                    
-                case .HumanEcology:
-                    parsedData = data.filter { str in
-                        str.contains(getTimeStamp)
-                    }.flatMap({ $0 })
-                    
-                    if let damAIndex = parsedData.firstIndex(of: "[Dam-A]"),
-                       let pangeosIndex = parsedData.firstIndex(of: "[Pangeos]") {
-                        
-                        let range = pangeosIndex..<parsedData.endIndex
-                        parsedData.removeSubrange(range)
-                    }
-                    
-                    
-                case .MaterialScience:
-                    parsedData = data.filter { str in
-                        str.contains(getTimeStamp)
-                    }.flatMap({ $0 })
-                    
-                    if let jeongsikIndex = parsedData.firstIndex(of: "[정식]"),
-                       let ilpoomIndex = parsedData.firstIndex(of: "[일품]") {
-                        
-                        let range = ilpoomIndex..<parsedData.endIndex
-                        parsedData.removeSubrange(range)
-                    }
-                    
-                case .ResidenceOne, .ResidenceTwo:
-                    parsedData = data.filter { str in
-                        str.contains(getTimeStamp)
-                    }.flatMap({ $0 })
-                    
-                    
-                case .HangwonPark:
-                    var result = data.filter { str in
-                        str.contains(getTimeStamp)
-                    }.flatMap({ $0 })
-                    
-                    if let cornerAIndex = result.firstIndex(of: "[코너 A]"),
-                       let cornerBIndex = result.firstIndex(of: "[코너 B]") {
-                        
-                        let range = cornerBIndex..<result.endIndex
-                        result.removeSubrange(range)
-                    }
-                    
-                }
-                
-                parsedData = parsedData.filter { str in
-                    return str != "-"
-                }
-                completion(.success(parsedData))
-                
-            case .failure(let error):
-                completion(.failure(error))
-                
-            }
-        }
-    }
-    
-    
-    static func parsingAsyncAndLocal(type: RestaurantType, completion: @escaping (Result<[String], Error>) -> Void) {
         
         let dateText: String = {
             let date = Date()
             return date.keyText
         }()
 //        if false {
-        print(UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)"))
-        if isUserDefaultDataToday(type: type), let data = UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
+        print(UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)"))
+        if isUserDefaultDataToday(type: type), let data = UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
 //            var data: [[String]] = []
             var parsedData = [String]()
             
@@ -218,10 +144,10 @@ struct ParsingManager {
                     })
                     
                     if shouldUserDefaultUpdate(type: type) {
-                        UserDefaults.standard.set("\(dateText)", forKey: "DateOf\(type.name)")
-                        print(UserDefaults.standard.string(forKey: "DateOf\(type.name)"))
-                        UserDefaults.standard.set(parsed, forKey: "TodayMenuOf\(type.name)")
-                        print(UserDefaults.standard.array(forKey: "TodayMenuOf\(type.name)"))
+                        UserDefaults.shared.set("\(dateText)", forKey: "DateOf\(type.name)")
+                        print(UserDefaults.shared.string(forKey: "DateOf\(type.name)"))
+                        UserDefaults.shared.set(parsed, forKey: "TodayMenuOf\(type.name)")
+                        print(UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)"))
                     }
                     
                     var parsedData = [String]()

--- a/ChulChulHanyangWidget/Manager/ParsingManager.swift
+++ b/ChulChulHanyangWidget/Manager/ParsingManager.swift
@@ -69,10 +69,8 @@ struct ParsingManager {
             let date = Date()
             return date.keyText
         }()
-//        if false {
-        print(UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)"))
+
         if isUserDefaultDataToday(type: type), let data = UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)") as? [[String]] {
-//            var data: [[String]] = []
             var parsedData = [String]()
             
             let getTimeStamp = getMealTime(type: type)
@@ -145,9 +143,7 @@ struct ParsingManager {
                     
                     if shouldUserDefaultUpdate(type: type) {
                         UserDefaults.shared.set("\(dateText)", forKey: "DateOf\(type.name)")
-                        print(UserDefaults.shared.string(forKey: "DateOf\(type.name)"))
                         UserDefaults.shared.set(parsed, forKey: "TodayMenuOf\(type.name)")
-                        print(UserDefaults.shared.array(forKey: "TodayMenuOf\(type.name)"))
                     }
                     
                     var parsedData = [String]()
@@ -172,7 +168,6 @@ struct ParsingManager {
                             parsedData.removeSubrange(range)
                         }
                         
-                        
                     case .MaterialScience:
                         parsedData = data.filter { str in
                             str.contains(getTimeStamp)
@@ -189,6 +184,7 @@ struct ParsingManager {
                         parsedData = data.filter { str in
                             str.contains(getTimeStamp)
                         }.flatMap({ $0 })
+                        
                     case .HangwonPark:
                         var result = data.filter { str in
                             str.contains(getTimeStamp)

--- a/ChulChulHanyangWidgetExtension.entitlements
+++ b/ChulChulHanyangWidgetExtension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ChulChulHanyang</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## 관련 이슈
- close #32 
## 🍚 구현/변경 사항 및 이유
1. Extension과 App간에 데이터 연결을 위해 App group 사용
2. 파싱함수 refactoring

## 🍚 참고 사항
위젯에서 데이터가 불러와져 있기 때문에, 앱 접속시 바로 학식 메뉴를 확인 할 수 있다. 
![Simulator Screen Recording - iPhone 13 - 2022-11-01 at 08 55 22](https://user-images.githubusercontent.com/39371835/199130794-76d94c49-eca3-4be1-bca4-17ec7b51a1e3.gif)

